### PR TITLE
feat: (misc) handle watching status based on number of server

### DIFF
--- a/bot/server_settings.go
+++ b/bot/server_settings.go
@@ -148,7 +148,7 @@ func (bot *ModeratorBot) updateServersWatched() error {
 	updateStatusData := &discordgo.UpdateStatusData{Status: "online"}
 	updateStatusData.Activities = make([]*discordgo.Activity, 1)
 	updateStatusData.Activities[0] = &discordgo.Activity{
-		Name: fmt.Sprintf("%v servers", serversActive),
+		Name: fmt.Sprintf("%v %v", serversActive, handlePlural("server", "s", int(serversActive))),
 		Type: discordgo.ActivityTypeWatching,
 		URL:  moderaterRepoUrl,
 	}

--- a/bot/util.go
+++ b/bot/util.go
@@ -108,3 +108,11 @@ func (bot *ModeratorBot) DeleteAllCommands() {
 		}
 	}
 }
+
+// handlePlural returns the provided `src` and add `suf` if `count` is more than 1
+func handlePlural(src, suf string, count int) string {
+	if count > 1 {
+		return src + suf
+	}
+	return src
+}


### PR DESCRIPTION
This will make the bot status to "Watching 1 server" or "Watching 100 servers" based on number of servers it's watching.
PS: the code autoformat on save of `gofumpt` is terrible and I don't know how to make it not doing this so apologize beforehand.
